### PR TITLE
Support macOS some shortcuts

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -13,6 +13,8 @@ const readline = require('readline');
 const app = electron.app;
 // Module to create native browser window.
 const BrowserWindow = electron.BrowserWindow;
+// Module to create native application menus and context menus.
+const Menu = electron.Menu;
 
 const isWin = /^win/.test(os.platform());
 const resoucesDir = isDev ? path.join(__dirname, '..') : path.join(__dirname, '..', '..');
@@ -123,6 +125,34 @@ app.on('ready', function() {
             }
         }
     });
+
+    const template = [{
+        label: 'Edit',
+        submenu: [
+            { role: 'undo' },
+            { role: 'redo' },
+            { type: 'separator' },
+            { role: 'cut' },
+            { role: 'copy' },
+            { role: 'paste' },
+            { role: 'selectall' }
+        ]
+    }];
+
+    if (process.platform === 'darwin') {
+        template.unshift({
+            label: app.getName(),
+            submenu: [
+                {role: 'about'},
+                {type: 'separator'},
+                {role: 'services', submenu: []},
+                {type: 'separator'},
+                {role: 'quit'}
+            ]
+        });
+    }
+
+    Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 });
 
 // Quit when all windows are closed.


### PR DESCRIPTION
In the version 1.0.0, some shortcuts(e.g. copy, paste, cut) can not be used on macOS. So I made some changes with reference to [official example code](https://electronjs.org/docs/api/menu#main-process).

Before
<img width="393" alt="nagome-electron-menu-before" src="https://user-images.githubusercontent.com/16757772/42127602-c34017c0-7cd6-11e8-8564-7b793d8d8489.png">

After
<img width="433" alt="nagome-electron-menu-after" src="https://user-images.githubusercontent.com/16757772/42127603-cab76652-7cd6-11e8-85c8-c7350dfbf216.png">
